### PR TITLE
Fix: Update connection string for dotnet-server in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     networks:
       - fop-imt-network
     environment:
+      - ConnectionStrings__DefaultConnection=Server=postgres;Database=FrontEASE;Port=5432;User Id=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};Pooling=true;
       - SEED_DB=${SEED_DB:-false}
   
   dotnet-client:


### PR DESCRIPTION
This pull request makes a small change to the `docker-compose.yml` file, adding a new environment variable for the database connection string. This will help configure the application's connection to the PostgreSQL database.

* Added the `ConnectionStrings__DefaultConnection` environment variable to the `services` section for improved database configuration.