### PR TITLE
Cloned tasks now have the cloning entity as an author

### DIFF
--- a/src/FrontEASE.Application/AppServices/Tasks/TaskAppService.cs
+++ b/src/FrontEASE.Application/AppServices/Tasks/TaskAppService.cs
@@ -131,8 +131,17 @@ namespace FrontEASE.Application.AppServices.Tasks
 
         public async Task<IList<TaskDto>> Duplicate(Guid id, TaskDuplicateActionRequestDto request, CancellationToken cancellationToken)
         {
+            var userMail = contextAccessor.HttpContext!.User.FindFirst(ClaimTypes.Email)!.Value;
+            var user = await userService.Load(userMail, cancellationToken);
+            var currentUserID = Guid.Parse(user!.Id);
+
             var duplicatedEntity = await taskService.Load(id, cancellationToken);
-            var duplicates = await taskService.Duplicate(duplicatedEntity, request.Name, request.Copies, cancellationToken);
+
+            var isOwner = duplicatedEntity.AuthorID == currentUserID;
+            var isSuperadmin = user?.UserRole?.RoleId == appSettings.AuthSettings?.Defaults?.Roles?.SuperadminGuid?.ToString();
+            var preserveLinkedEntities = isOwner || isSuperadmin;
+
+            var duplicates = await taskService.Duplicate(duplicatedEntity, request.Name, request.Copies, currentUserID, preserveLinkedEntities, cancellationToken);
             var duplicatesDto = mapper.Map<IList<TaskDto>>(duplicates);
             return duplicatesDto;
         }

--- a/src/FrontEASE.Client/Pages/Tasks/Manipulate/Components/TaskCloneDataFormSection.razor
+++ b/src/FrontEASE.Client/Pages/Tasks/Manipulate/Components/TaskCloneDataFormSection.razor
@@ -34,7 +34,7 @@
                 <Fields>
                     <FieldLabel For="@(GetElementIdByOperation(nameof(TaskDuplicateActionRequestDto.Copies)))" RequiredIndicator>
                         <Span>
-                            @($"{resourceHandler.GetResource(AttributeExtensions.GetResourceFieldValue<TaskDuplicateActionRequestDto>(nameof(TaskDuplicateActionRequestDto.Copies), PropertyDisplayResourceType.FIELD))}")
+                            @($"{resourceHandler.GetResource(AttributeExtensions.GetResourceFieldValue<TaskDuplicateActionRequestDto>(nameof(TaskDuplicateActionRequestDto.Copies), PropertyDisplayResourceType.FIELD))}: ")
                         </Span>
                         <Span TextWeight="TextWeight.Bold">
                             @(CloneModel.Copies)

--- a/src/FrontEASE.Domain/Services/Tasks/ITaskService.cs
+++ b/src/FrontEASE.Domain/Services/Tasks/ITaskService.cs
@@ -1,6 +1,4 @@
-﻿using FrontEASE.Domain.Entities.Companies;
-using FrontEASE.Domain.Entities.Shared.Users;
-using FrontEASE.Domain.Entities.Tasks.Actions.Filtering;
+﻿using FrontEASE.Domain.Entities.Tasks.Actions.Filtering;
 using FrontEASE.Domain.Entities.Tasks.Configs.Modules.Options;
 using FrontEASE.Shared.Data.Enums.Tasks;
 
@@ -16,7 +14,7 @@ namespace FrontEASE.Domain.Services.Tasks
         Task<IList<Entities.Tasks.Task>> LoadAllBase(Guid? userID, TaskFilterActionRequest? filter, CancellationToken cancellationToken);
         Task<Entities.Tasks.Task> Create(Entities.Tasks.Task task, CancellationToken cancellationToken);
         Task<Entities.Tasks.Task> Update(Entities.Tasks.Task task, CancellationToken cancellationToken);
-        Task<IList<Entities.Tasks.Task>> Duplicate(Entities.Tasks.Task task, string taskName, int copies, CancellationToken cancellationToken);
+        Task<IList<Entities.Tasks.Task>> Duplicate(Entities.Tasks.Task task, string taskName, int copies, Guid authorID, bool preserveLinkedEntities, CancellationToken cancellationToken);
         Task Delete(IList<Entities.Tasks.Task> tasks, CancellationToken cancellationToken);
         Task ChangeState(IList<Entities.Tasks.Task> task, TaskState state, CancellationToken cancellationToken);
         Task<Entities.Tasks.Task> Share(Entities.Tasks.Task task, CancellationToken cancellationToken);

--- a/src/FrontEASE.Domain/Services/Tasks/TaskService.cs
+++ b/src/FrontEASE.Domain/Services/Tasks/TaskService.cs
@@ -142,16 +142,23 @@ namespace FrontEASE.Domain.Services.Tasks
             return updated;
         }
 
-        public async Task<IList<Entities.Tasks.Task>> Duplicate(Entities.Tasks.Task task, string baseName, int copies, CancellationToken cancellationToken)
+        public async Task<IList<Entities.Tasks.Task>> Duplicate(Entities.Tasks.Task task, string baseName, int copies, Guid authorID, bool preserveLinkedEntities, CancellationToken cancellationToken)
         {
             var duplicates = new List<Entities.Tasks.Task>();
+            var connectedEntities = await SelectConnectedEntities(task, cancellationToken);
+
+            if (!preserveLinkedEntities)
+            {
+                var currentUser = await userRepository.Load(authorID, cancellationToken) ?? throw new NotFoundException();
+                connectedEntities = ([currentUser], [], connectedEntities.Tags);
+            }
+
             for (var i = 0; i < copies; i++)
             {
                 var newTask = new Entities.Tasks.Task();
                 mapper.Map(task, newTask);
-                newTask.AuthorID = task.AuthorID;
+                newTask.AuthorID = authorID;
 
-                var connectedEntities = await SelectConnectedEntities(task, cancellationToken);
                 UpdateConnectedEntities(newTask, connectedEntities);
                 CleanTaskRunData(newTask);
 


### PR DESCRIPTION
Following changes have been made:
- Cloning user is now the author of the cloned tasks
- When cloning user is not the owner or superadmin, members / groups are unlinked from the clones