### PR TITLE
available models JSON editor with Ace Editor integration

### DIFF
--- a/src/FrontEASE.Application/AppServices/Shared/Core/CoreAppService.cs
+++ b/src/FrontEASE.Application/AppServices/Shared/Core/CoreAppService.cs
@@ -46,5 +46,9 @@ namespace FrontEASE.Application.AppServices.Shared.Core
         }
 
         public async Task UpdateModels(CancellationToken cancellationToken) => await coreService.UpdateCoreModels(cancellationToken);
+
+        public async Task<string> GetAvailableModels(CancellationToken cancellationToken) => await coreService.GetAvailableModels(cancellationToken);
+
+        public async Task SaveAvailableModels(string modelsJson, CancellationToken cancellationToken) => await coreService.SaveAvailableModels(modelsJson, cancellationToken);
     }
 }

--- a/src/FrontEASE.Application/AppServices/Shared/Core/ICoreAppService.cs
+++ b/src/FrontEASE.Application/AppServices/Shared/Core/ICoreAppService.cs
@@ -8,5 +8,7 @@ namespace FrontEASE.Application.AppServices.Shared.Core
         Task<IList<ModuleImportBulkActionResultDto>> ImportModules(GlobalPreferenceCoreModuleDto modulesContent, CancellationToken cancellationToken);
         Task DeleteModule(string shortName, CancellationToken cancellationToken);
         Task UpdateModels(CancellationToken cancellationToken);
+        Task<string> GetAvailableModels(CancellationToken cancellationToken);
+        Task SaveAvailableModels(string modelsJson, CancellationToken cancellationToken);
     }
 }

--- a/src/FrontEASE.Client/Pages/Management/Tabs/Core/Extended/Models/Components/CoreExtendedAvailableModelsSectionForm.razor
+++ b/src/FrontEASE.Client/Pages/Management/Tabs/Core/Extended/Models/Components/CoreExtendedAvailableModelsSectionForm.razor
@@ -1,0 +1,184 @@
+@inject IResourceHandler resourceHandler
+@inject ICoreApiService coreApiService
+@inject IUIService uiService
+@inject Blazored.Toast.Services.IToastService toastService
+
+@implements IDisposable
+@implements IAsyncDisposable
+
+@if (!isInitialized)
+{
+    <ContentLoadSpinner />
+}
+else
+{
+    <Column ColumnSize="ColumnSize.IsFull" Display="Display.Block" Margin="Margin.Is2.FromTop.Is4.FromBottom">
+        <Form Margin="Margin.Is4.FromTop" Class="text-form-size">
+            <Fields>
+                <Field ColumnSize="ColumnSize.Is12">
+                    <CodeEditor @ref="codeEditorRef"
+                                Value="@modelsJsonContent"
+                                Language="json"
+                                ReadOnly="@(saveInProgress || loadInProgress)" />
+                </Field>
+            </Fields>
+
+            @if (!string.IsNullOrWhiteSpace(validationError))
+            {
+                <Fields>
+                    <Field ColumnSize="ColumnSize.Is12">
+                        <Alert Color="Color.Danger" Visible>
+                            <AlertMessage>
+                                @validationError
+                            </AlertMessage>
+                        </Alert>
+                    </Field>
+                </Fields>
+            }
+
+            <Fields>
+                <Row>
+                    <Column ColumnSize="ColumnSize.Is3.OnWidescreen" Margin="Margin.Is5.FromTop">
+                        <Button Color="Color.Primary" Clicked="@LoadModels" Class="btn button btn-sized full-width" Disabled="@(loadInProgress || saveInProgress)" TextWeight="TextWeight.Bold">
+                            @if (loadInProgress)
+                            {
+                                <SpinnerButton DisplayText="@(resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Load}"))" SmallControlSpinner="true" TextSize="TextSize.Medium" />
+                            }
+                            else
+                            {
+                                @(resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Load}"))
+                            }
+                        </Button>
+                    </Column>
+                    <Column ColumnSize="ColumnSize.Is3.OnWidescreen" Margin="Margin.IsAuto.FromStart.Is5.FromTop">
+                        <Button Class="btn button btn-sized full-width bg-custom-info text-custom-info" Clicked="@SaveModels" Disabled="@(saveInProgress || loadInProgress)" TextWeight="TextWeight.Bold">
+                            @if (saveInProgress)
+                            {
+                                <SpinnerButton DisplayText="@(resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Save}"))" SmallControlSpinner="true" TextSize="TextSize.Medium" />
+                            }
+                            else
+                            {
+                                @(resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Save}"))
+                            }
+                        </Button>
+                    </Column>
+                </Row>
+            </Fields>
+        </Form>
+    </Column>
+}
+
+@code {
+    private CodeEditor? codeEditorRef;
+    private string modelsJsonContent = string.Empty;
+    private string? validationError;
+
+    private bool isInitialized;
+    private bool loadInProgress;
+    private bool saveInProgress;
+    private bool isDisposed;
+
+    private async Task RefreshViewAsync()
+    {
+        if (isDisposed) { return; }
+        await InvokeAsync(StateHasChanged);
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        uiService.RefreshRequested += RefreshViewAsync;
+        await LoadModels();
+        isInitialized = true;
+        await base.OnInitializedAsync();
+    }
+
+    private async Task LoadModels()
+    {
+        loadInProgress = true;
+        validationError = null;
+
+        var result = await coreApiService.GetAvailableModels();
+        if (result is not null)
+        {
+            modelsJsonContent = FormatJson(result);
+
+            if (codeEditorRef is not null)
+            {
+                await codeEditorRef.SetValue(modelsJsonContent);
+            }
+
+            var message = $"{resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Result}.{UIStateConstants.ActionSuccess}")} - {resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Load}")}";
+            toastService.ShowSuccess(message);
+        }
+
+        loadInProgress = false;
+    }
+
+    private async Task SaveModels()
+    {
+        saveInProgress = true;
+        validationError = null;
+
+        var currentContent = codeEditorRef is not null ? await codeEditorRef.GetValue() : modelsJsonContent;
+
+        if (!ValidateJson(currentContent))
+        {
+            saveInProgress = false;
+            return;
+        }
+
+        var result = await coreApiService.SaveAvailableModels(currentContent);
+        if (result)
+        {
+            var message = $"{resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Result}.{UIStateConstants.ActionSuccess}")} - {resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Save}")}";
+            toastService.ShowSuccess(message);
+        }
+
+        saveInProgress = false;
+    }
+
+    private bool ValidateJson(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            validationError = resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Specific}.{UIStateConstants.Validation}.{UIValidationConstants.JsonEmpty}");
+            return false;
+        }
+
+        try
+        {
+            System.Text.Json.JsonDocument.Parse(json);
+            return true;
+        }
+        catch (System.Text.Json.JsonException ex)
+        {
+            validationError = $"{resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Specific}.{UIStateConstants.Validation}.{UIValidationConstants.JsonInvalid}")}: {ex.Message}";
+            return false;
+        }
+    }
+
+    private static string FormatJson(string json)
+    {
+        try
+        {
+            var doc = System.Text.Json.JsonDocument.Parse(json);
+            return System.Text.Json.JsonSerializer.Serialize(doc, new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+        }
+        catch
+        {
+            return json;
+        }
+    }
+
+    public void Dispose()
+    {
+        isDisposed = true;
+        uiService.RefreshRequested -= RefreshViewAsync;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/FrontEASE.Client/Pages/Management/Tabs/Core/Extended/Models/CoreExtendedAvailableModelsSection.razor
+++ b/src/FrontEASE.Client/Pages/Management/Tabs/Core/Extended/Models/CoreExtendedAvailableModelsSection.razor
@@ -1,0 +1,6 @@
+@inject IResourceHandler resourceHandler
+
+<FormSectionHeader DisplayText="@(resourceHandler.GetResource($"{AttributeExtensions.GetCollectionResourceValue<GlobalPreferencesDto>()}.available-models"))" />
+<Divider Class="divider-main-thin bg-custom-light" Shadow="Shadow.Small" Margin="Margin.Is0.FromTop" />
+
+<CoreExtendedAvailableModelsSectionForm />

--- a/src/FrontEASE.Client/Pages/Management/Tabs/Core/Tabs/CoreManagementExtendedFunctionalityTab.razor
+++ b/src/FrontEASE.Client/Pages/Management/Tabs/Core/Tabs/CoreManagementExtendedFunctionalityTab.razor
@@ -1,3 +1,4 @@
 ﻿<Container Fluid Padding="Padding.Is3" Border="Border.Is1.RoundedBottom" Shadow="Shadow.Small" Class="rounded-top-right-1 border-custom-light">
+    <CoreExtendedAvailableModelsSection />
     <CoreExtendedUpdateModelsSection />
 </Container>

--- a/src/FrontEASE.Client/Services/ApiServices/Shared/Core/CoreApiService.cs
+++ b/src/FrontEASE.Client/Services/ApiServices/Shared/Core/CoreApiService.cs
@@ -49,5 +49,31 @@ namespace FrontEASE.Client.Services.ApiServices.Shared.Core
             }
             return true;
         }
+
+        public async Task<string?> GetAvailableModels()
+        {
+            var url = $"{CoreControllerConstants.BaseUrl}/{CoreControllerConstants.AvailableModels}";
+            var response = await _client.GetAsync(url);
+            var expectedCodes = new List<HttpStatusCode>() { HttpStatusCode.OK };
+
+            if (!expectedCodes.Contains(response.StatusCode))
+            {
+                await _errorHandlingService.HandleErrorResponse(response);
+                return null;
+            }
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        public async Task<bool> SaveAvailableModels(string modelsJson)
+        {
+            var url = $"{CoreControllerConstants.BaseUrl}/{CoreControllerConstants.AvailableModels}";
+            var response = await _client.PutAsJsonAsync(url, modelsJson);
+            if (response.StatusCode != HttpStatusCode.NoContent)
+            {
+                await _errorHandlingService.HandleErrorResponse(response);
+                return false;
+            }
+            return true;
+        }
     }
 }

--- a/src/FrontEASE.Client/Services/ApiServices/Shared/Core/ICoreApiService.cs
+++ b/src/FrontEASE.Client/Services/ApiServices/Shared/Core/ICoreApiService.cs
@@ -8,5 +8,7 @@ namespace FrontEASE.Client.Services.ApiServices.Shared.Core
         Task<IList<ModuleImportBulkActionResultDto>> ImportTaskCoreModules(GlobalPreferenceCoreModuleDto modules);
         Task<bool> DeleteTaskCoreModule(string moduleName);
         Task<bool> UpdateCoreModels();
+        Task<string?> GetAvailableModels();
+        Task<bool> SaveAvailableModels(string modelsJson);
     }
 }

--- a/src/FrontEASE.Client/Shared/Components/Forms/CodeEditor.razor
+++ b/src/FrontEASE.Client/Shared/Components/Forms/CodeEditor.razor
@@ -1,0 +1,78 @@
+@inject IJSRuntime jsRuntime
+
+@implements IAsyncDisposable
+
+<div id="@_elementId" class="code-editor-container"></div>
+
+@code {
+    [Parameter]
+    public string Value { get; set; } = string.Empty;
+
+    [Parameter]
+    public EventCallback<string> ValueChanged { get; set; }
+
+    [Parameter]
+    public string Language { get; set; } = "json";
+
+    [Parameter]
+    public bool ReadOnly { get; set; }
+
+    private string _elementId = $"code-editor-{Guid.NewGuid():N}";
+    private bool _initialized;
+    private bool _disposed;
+    private string _lastSetValue = string.Empty;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await jsRuntime.InvokeVoidAsync("codeEditor.create", _elementId, Language, ReadOnly, Value);
+            _lastSetValue = Value;
+            _initialized = true;
+        }
+    }
+
+    protected override async Task OnParametersSetAsync()
+    {
+        if (!_initialized || _disposed) { return; }
+
+        if (Value != _lastSetValue)
+        {
+            await jsRuntime.InvokeVoidAsync("codeEditor.setValue", _elementId, Value);
+            _lastSetValue = Value;
+        }
+
+        await jsRuntime.InvokeVoidAsync("codeEditor.setReadOnly", _elementId, ReadOnly);
+    }
+
+    public async Task<string> GetValue()
+    {
+        if (_disposed) { return string.Empty; }
+        var value = await jsRuntime.InvokeAsync<string>("codeEditor.getValue", _elementId);
+        _lastSetValue = value;
+        if (ValueChanged.HasDelegate)
+        {
+            await ValueChanged.InvokeAsync(value);
+        }
+        return value;
+    }
+
+    public async Task SetValue(string value)
+    {
+        if (_disposed || !_initialized) { return; }
+        await jsRuntime.InvokeVoidAsync("codeEditor.setValue", _elementId, value);
+        _lastSetValue = value;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed) { return; }
+        _disposed = true;
+
+        try
+        {
+            await jsRuntime.InvokeVoidAsync("codeEditor.dispose", _elementId);
+        }
+        catch (JSDisconnectedException) { }
+    }
+}

--- a/src/FrontEASE.Client/wwwroot/index.html
+++ b/src/FrontEASE.Client/wwwroot/index.html
@@ -28,7 +28,9 @@
         <div class="loading-progress-text"></div>
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.36.5/src-min-noconflict/ace.js" crossorigin="anonymous"></script>
     <script src="_framework/blazor.webassembly.js"></script>
+    <script src="scripts/code-editor.js"></script>
     <script src="scripts/app.js"></script>
 </body>
 

--- a/src/FrontEASE.Client/wwwroot/scripts/code-editor.js
+++ b/src/FrontEASE.Client/wwwroot/scripts/code-editor.js
@@ -1,0 +1,70 @@
+window.codeEditor = {
+    _instances: {},
+
+    create: function (elementId, language, readOnly, value) {
+        const container = document.getElementById(elementId);
+        if (!container || this._instances[elementId]) { return; }
+
+        const editor = ace.edit(container, {
+            mode: "ace/mode/" + (language || "json"),
+            theme: "ace/theme/one_dark",
+            value: value || "",
+            readOnly: readOnly || false,
+            fontSize: 14,
+            fontFamily: "'Consolas', 'Courier New', monospace",
+            showPrintMargin: false,
+            tabSize: 2,
+            useSoftTabs: true,
+            wrap: false,
+            minLines: 20,
+            maxLines: 40,
+            showGutter: true,
+            highlightActiveLine: true,
+            enableBasicAutocompletion: false
+        });
+
+        this._instances[elementId] = editor;
+    },
+
+    getValue: function (elementId) {
+        const editor = this._instances[elementId];
+        return editor ? editor.getValue() : "";
+    },
+
+    setValue: function (elementId, value) {
+        const editor = this._instances[elementId];
+        if (editor) {
+            editor.setValue(value || "", -1);
+            editor.clearSelection();
+        }
+    },
+
+    setReadOnly: function (elementId, readOnly) {
+        const editor = this._instances[elementId];
+        if (editor) {
+            editor.setReadOnly(readOnly);
+        }
+    },
+
+    setLanguage: function (elementId, language) {
+        const editor = this._instances[elementId];
+        if (editor) {
+            editor.session.setMode("ace/mode/" + language);
+        }
+    },
+
+    resize: function (elementId) {
+        const editor = this._instances[elementId];
+        if (editor) {
+            editor.resize();
+        }
+    },
+
+    dispose: function (elementId) {
+        const editor = this._instances[elementId];
+        if (editor) {
+            editor.destroy();
+            delete this._instances[elementId];
+        }
+    }
+};

--- a/src/FrontEASE.Client/wwwroot/styles/app.css
+++ b/src/FrontEASE.Client/wwwroot/styles/app.css
@@ -1041,3 +1041,10 @@ nav.navbar {
     max-height: 50vh;
     overflow-y: auto !important;
 }
+
+/* CODE EDITOR (Ace) */
+.code-editor-container {
+    min-height: 400px;
+    border: 1px solid var(--b-theme-background-light);
+    border-radius: 4px;
+}

--- a/src/FrontEASE.Domain/Services/Core/Connector/CoreConnector.cs
+++ b/src/FrontEASE.Domain/Services/Core/Connector/CoreConnector.cs
@@ -66,6 +66,38 @@ namespace FrontEASE.Domain.Services.Core.Connector
             }
         }
 
+        public async Task<string> GetAvailableModels(CancellationToken cancellationToken)
+        {
+            var url = new Uri($"{_appSettings.IntegrationSettings!.PythonCore!.Server!.BaseUrl}/available-models");
+            var response = await _httpClient.GetAsync(url, cancellationToken);
+            if (response.IsSuccessStatusCode)
+            {
+                return await response.Content.ReadAsStringAsync(cancellationToken);
+            }
+            else
+            {
+                var failResult = await response.Content.ReadAsStringAsync(cancellationToken);
+                throw new ApplicationException($"{nameof(GetAvailableModels)} - Call FAILED - Exception: {failResult}");
+            }
+        }
+
+        public async Task<bool> SaveAvailableModels(string modelsJson, CancellationToken cancellationToken)
+        {
+            var url = new Uri($"{_appSettings.IntegrationSettings!.PythonCore!.Server!.BaseUrl}/available-models");
+            var content = new StringContent(modelsJson, Encoding.UTF8, CoreConnectorConstants.CoreDataAPIFormat);
+
+            var response = await _httpClient.PutAsync(url, content, cancellationToken);
+            if (response.IsSuccessStatusCode)
+            {
+                return true;
+            }
+            else
+            {
+                var failResult = await response.Content.ReadAsStringAsync(cancellationToken);
+                throw new ApplicationException($"{nameof(SaveAvailableModels)} - Call FAILED - Exception: {failResult}");
+            }
+        }
+
         public async Task<bool> DeleteModule(string shortName, CancellationToken cancellationToken)
         {
             var url = new Uri($"{_appSettings.IntegrationSettings!.PythonCore!.Server!.BaseUrl}/system/delete/{shortName}");

--- a/src/FrontEASE.Domain/Services/Core/Connector/ICoreConnector.cs
+++ b/src/FrontEASE.Domain/Services/Core/Connector/ICoreConnector.cs
@@ -21,6 +21,8 @@ namespace FrontEASE.Domain.Services.Core.Connector
         Task ImportModule(Entities.Shared.Files.File moduleFile, CancellationToken cancellationToken);
         Task<bool> DeleteModule(string shortName, CancellationToken cancellationToken);
         Task<bool> UpdateModels(CancellationToken cancellationToken);
+        Task<string> GetAvailableModels(CancellationToken cancellationToken);
+        Task<bool> SaveAvailableModels(string modelsJson, CancellationToken cancellationToken);
 
         Task<IList<TaskInfoCoreDto>> GetTaskInfos(CancellationToken cancellationToken);
         Task<IList<TaskFullCoreDto>> GetTasksFullData(CancellationToken cancellationToken);

--- a/src/FrontEASE.Domain/Services/Core/CoreService.cs
+++ b/src/FrontEASE.Domain/Services/Core/CoreService.cs
@@ -7,5 +7,7 @@ namespace FrontEASE.Domain.Services.Core
         public async Task ImportCoreModule(Entities.Shared.Files.File fileModule, CancellationToken cancellationToken) => await coreConnector.ImportModule(fileModule, cancellationToken);
         public async Task DeleteCoreModule(string name, CancellationToken cancellationToken) => await coreConnector.DeleteModule(name, cancellationToken);
         public async Task UpdateCoreModels(CancellationToken cancellationToken) => await coreConnector.UpdateModels(cancellationToken);
+        public async Task<string> GetAvailableModels(CancellationToken cancellationToken) => await coreConnector.GetAvailableModels(cancellationToken);
+        public async Task SaveAvailableModels(string modelsJson, CancellationToken cancellationToken) => await coreConnector.SaveAvailableModels(modelsJson, cancellationToken);
     }
 }

--- a/src/FrontEASE.Domain/Services/Core/ICoreService.cs
+++ b/src/FrontEASE.Domain/Services/Core/ICoreService.cs
@@ -5,5 +5,7 @@
         Task ImportCoreModule(Entities.Shared.Files.File fileModule, CancellationToken cancellationToken);
         Task DeleteCoreModule(string name, CancellationToken cancellationToken);
         Task UpdateCoreModels(CancellationToken cancellationToken);
+        Task<string> GetAvailableModels(CancellationToken cancellationToken);
+        Task SaveAvailableModels(string modelsJson, CancellationToken cancellationToken);
     }
 }

--- a/src/FrontEASE.Infrastructure/Data/Configuration/Shared/Resources/Defaults/DefaultResourcesConfiguration.cs
+++ b/src/FrontEASE.Infrastructure/Data/Configuration/Shared/Resources/Defaults/DefaultResourcesConfiguration.cs
@@ -144,6 +144,9 @@ namespace FrontEASE.Infrastructure.Data.Configuration.Shared.Resources.Defaults
                 new Resource(){ CountryCodeID = LanguageCode.EN, ResourceCode = $"{UIConstants.Data}.{UIConstants.Specific}.{UIStateConstants.Validation}.{UIValidationConstants.ParameterTagFormat}", Value="Value must be contain only uppercase letters and numbers (potentially divided by symbols '_' and '-')." },
 
                 new Resource(){ CountryCodeID = LanguageCode.EN, ResourceCode = $"{UIConstants.Data}.{UIConstants.Specific}.{UIStateConstants.Validation}.{UIValidationConstants.CorePackageAlreadyPresent}", Value="The package \"{0}\" is already present in the list of core packages. Please make sure to uninstall previous version first when attempting to upgrade."},
+
+                new Resource(){ CountryCodeID = LanguageCode.EN, ResourceCode = $"{UIConstants.Data}.{UIConstants.Specific}.{UIStateConstants.Validation}.{UIValidationConstants.JsonEmpty}", Value="JSON content cannot be empty."},
+                new Resource(){ CountryCodeID = LanguageCode.EN, ResourceCode = $"{UIConstants.Data}.{UIConstants.Specific}.{UIStateConstants.Validation}.{UIValidationConstants.JsonInvalid}", Value="Invalid JSON format"},
             ];
         }
 
@@ -179,6 +182,7 @@ namespace FrontEASE.Infrastructure.Data.Configuration.Shared.Resources.Defaults
 
                 new Resource() { CountryCodeID = LanguageCode.EN, ResourceCode = $"{AttributeExtensions.GetCollectionResourceValue<GlobalPreferencesDto>()}.{UIStateConstants.Text}", Value = "Large Language Models" },
                 new Resource() { CountryCodeID = LanguageCode.EN, ResourceCode = $"{AttributeExtensions.GetCollectionResourceValue<GlobalPreferencesDto>()}.{UIStateConstants.Explanation}", Value = "Update the versions of Large Language Models used by the EASE Core." },
+                new Resource() { CountryCodeID = LanguageCode.EN, ResourceCode = $"{AttributeExtensions.GetCollectionResourceValue<GlobalPreferencesDto>()}.available-models", Value = "Available Models Configuration" },
             ];
         }
 
@@ -294,6 +298,8 @@ namespace FrontEASE.Infrastructure.Data.Configuration.Shared.Resources.Defaults
                 new Resource(){ CountryCodeID = LanguageCode.EN, ResourceCode = $"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Hide}", Value="Hide" },
                 new Resource(){ CountryCodeID = LanguageCode.EN, ResourceCode = $"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Show}", Value="Show" },
                 new Resource(){ CountryCodeID = LanguageCode.EN, ResourceCode = $"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Share}", Value="Share" },
+                new Resource(){ CountryCodeID = LanguageCode.EN, ResourceCode = $"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Edit}", Value="Edit" },
+                new Resource(){ CountryCodeID = LanguageCode.EN, ResourceCode = $"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Preview}", Value="Preview" },
                 new Resource(){ CountryCodeID = LanguageCode.EN, ResourceCode = $"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.BackToHomepage}", Value="Return to Home page" },
 
                 /* Data Manipulations */

--- a/src/FrontEASE.Server/Controllers/Admin/CoreController.cs
+++ b/src/FrontEASE.Server/Controllers/Admin/CoreController.cs
@@ -97,5 +97,53 @@ namespace FrontEASE.Server.Controllers.Admin
             }
             return result;
         }
+
+        /// <summary>
+        /// Gets the available models configuration
+        /// </summary>
+        /// <returns>Available models JSON content.</returns>
+        [HttpGet($"{CoreControllerConstants.BaseUrl}/{CoreControllerConstants.AvailableModels}")]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(UnauthorizedResultDto), (int)HttpStatusCode.Unauthorized)]
+        public async Task<IActionResult> GetAvailableModels()
+        {
+            IActionResult result;
+            try
+            {
+                var response = await coreAppService.GetAvailableModels(CancellationToken.None);
+                result = GetHttpResult(HttpStatusCode.OK, response);
+            }
+            catch (Exception ex)
+            {
+                var response = ProcessApiException(ex);
+                result = GetHttpResult(response!.StatusCode, response);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Saves the available models configuration
+        /// </summary>
+        /// <param name="modelsJson">JSON string with the available models configuration.</param>
+        /// <returns>No content on success.</returns>
+        [HttpPut($"{CoreControllerConstants.BaseUrl}/{CoreControllerConstants.AvailableModels}")]
+        [ProducesResponseType((int)HttpStatusCode.NoContent)]
+        [ProducesResponseType(typeof(UnauthorizedResultDto), (int)HttpStatusCode.Unauthorized)]
+        [ProducesResponseType(typeof(BadRequestResultDto), (int)HttpStatusCode.BadRequest)]
+        public async Task<IActionResult> SaveAvailableModels([FromBody, Required] string modelsJson)
+        {
+            IActionResult result;
+            try
+            {
+                await coreAppService.SaveAvailableModels(modelsJson, CancellationToken.None);
+                result = GetHttpResult(HttpStatusCode.NoContent);
+            }
+            catch (Exception ex)
+            {
+                var response = ProcessApiException(ex);
+                result = GetHttpResult(response!.StatusCode, response);
+            }
+            return result;
+        }
     }
 }

--- a/src/FrontEASE.Shared/Infrastructure/Constants/Controllers/Specific/CoreControllerConstants.cs
+++ b/src/FrontEASE.Shared/Infrastructure/Constants/Controllers/Specific/CoreControllerConstants.cs
@@ -6,6 +6,7 @@
 
         public const string Module = "module";
         public const string Models = "models";
+        public const string AvailableModels = "available-models";
 
         public const string NameParam = "{name}";
     }

--- a/src/FrontEASE.Shared/Infrastructure/Constants/UI/Generic/UIValidationConstants.cs
+++ b/src/FrontEASE.Shared/Infrastructure/Constants/UI/Generic/UIValidationConstants.cs
@@ -24,5 +24,8 @@
         public const string ParameterTagFormat = "ParameterTagFormat";
 
         public const string CorePackageAlreadyPresent = "CorePackageAlreadyPresent";
+
+        public const string JsonEmpty = "JsonEmpty";
+        public const string JsonInvalid = "JsonInvalid";
     }
 }

--- a/src/FrontEASE.Shared/Infrastructure/Constants/UI/Specific/UIActionConstants.cs
+++ b/src/FrontEASE.Shared/Infrastructure/Constants/UI/Specific/UIActionConstants.cs
@@ -30,5 +30,7 @@
         public const string Hide = "Hide";
         public const string Show = "Show";
         public const string Share = "Share";
+        public const string Edit = "Edit";
+        public const string Preview = "Preview";
     }
 }


### PR DESCRIPTION
## Summary
Full-stack feature for editing the EASE Core `available_models.json` 
configuration through the frontend. Includes a reusable Ace Editor code 
editor component for future use across the application.

## New Reusable Component
**`CodeEditor.razor`** (`Shared/Components/Forms/`) — wraps Ace Editor with 
Blazor JS interop. Parameters: `Value`, `Language` (json/python/yaml/...), 
`ReadOnly`. Usable anywhere via `<CodeEditor Language="json" Value="@data" />`.

## Architecture (full stack)
```
Python Core (GET/PUT /available-models)
  |
CoreConnector -> CoreService -> CoreAppService -> CoreController
  |                                                  |
ICoreConnector  ICoreService  ICoreAppService   GET/PUT /api/core/available-models
                                                     |
                                          CoreApiService (client HTTP)
                                                     |
                                    CoreExtendedAvailableModelsSectionForm.razor
                                              (Ace Editor UI)
```

## Changed Files

### New files (4)
- `Shared/Components/Forms/CodeEditor.razor` — reusable Ace Editor component
- `wwwroot/scripts/code-editor.js` — JS interop layer (create/get/set/dispose)
- `Pages/.../Extended/Models/CoreExtendedAvailableModelsSection.razor` — section wrapper
- `Pages/.../Extended/Models/Components/CoreExtendedAvailableModelsSectionForm.razor` — editor form

### Modified files (17)
| Layer | File | Change |
|-------|------|--------|
| **Client** | `index.html` | Ace Editor CDN + code-editor.js script |
| **Client** | `app.css` | `.code-editor-container` styles |
| **Client** | `CoreManagementExtendedFunctionalityTab.razor` | Added section reference |
| **Client** | `CoreApiService.cs` / `ICoreApiService.cs` | GET/PUT HTTP methods |
| **Server** | `CoreController.cs` | GET/PUT endpoints (Admin-only) |
| **Application** | `CoreAppService.cs` / `ICoreAppService.cs` | Pass-through methods |
| **Domain** | `CoreService.cs` / `ICoreService.cs` | Pass-through methods |
| **Domain** | `CoreConnector.cs` / `ICoreConnector.cs` | HTTP calls to Python Core |
| **Shared** | `CoreControllerConstants.cs` | `AvailableModels` route constant |
| **Shared** | `UIValidationConstants.cs` | `JsonEmpty`, `JsonInvalid` |
| **Shared** | `UIActionConstants.cs` | `Edit`, `Preview` |
| **Infrastructure** | `DefaultResourcesConfiguration.cs` | 5 new EN resources |

## Features
- JSON syntax highlighting, bracket matching, code folding, line numbers
- Load (reloads from server, overwrites local edits)
- Save (client-side JSON validation → server-side structure validation)
- Dark theme (`one_dark`) matching existing UI
- ReadOnly state during load/save operations

## Screenshots
Management → Core → Extended → Available Models Configuration

## Dependencies
- [Ace Editor v1.36.5](https://cdn.jsdelivr.net/npm/ace-builds@1.36.5/) (CDN, MIT license)
- Requires corresponding EASE Core PR for the Python endpoints
