### PR TITLE
ADD - module source code editor with Monaco integration

### DIFF
--- a/src/FrontEASE.Application/AppServices/Shared/Core/CoreAppService.cs
+++ b/src/FrontEASE.Application/AppServices/Shared/Core/CoreAppService.cs
@@ -45,6 +45,17 @@ namespace FrontEASE.Application.AppServices.Shared.Core
             await typelistService.LoadModuleTypes(true, cancellationToken);
         }
 
+        public async Task<string> ReadModule(string shortName, CancellationToken cancellationToken)
+        {
+            return await coreService.ReadCoreModule(shortName, cancellationToken);
+        }
+
+        public async Task UpdateModule(string shortName, string content, CancellationToken cancellationToken)
+        {
+            await coreService.UpdateCoreModule(shortName, content, cancellationToken);
+            await typelistService.LoadModuleTypes(true, cancellationToken);
+        }
+
         public async Task UpdateModels(CancellationToken cancellationToken) => await coreService.UpdateCoreModels(cancellationToken);
 
         public async Task<string> GetAvailableModels(CancellationToken cancellationToken) => await coreService.GetAvailableModels(cancellationToken);

--- a/src/FrontEASE.Application/AppServices/Shared/Core/ICoreAppService.cs
+++ b/src/FrontEASE.Application/AppServices/Shared/Core/ICoreAppService.cs
@@ -7,6 +7,8 @@ namespace FrontEASE.Application.AppServices.Shared.Core
     {
         Task<IList<ModuleImportBulkActionResultDto>> ImportModules(GlobalPreferenceCoreModuleDto modulesContent, CancellationToken cancellationToken);
         Task DeleteModule(string shortName, CancellationToken cancellationToken);
+        Task<string> ReadModule(string shortName, CancellationToken cancellationToken);
+        Task UpdateModule(string shortName, string content, CancellationToken cancellationToken);
         Task UpdateModels(CancellationToken cancellationToken);
         Task<string> GetAvailableModels(CancellationToken cancellationToken);
         Task SaveAvailableModels(string modelsJson, CancellationToken cancellationToken);

--- a/src/FrontEASE.Client/Pages/Management/Tabs/Core/Modules/Edit/ModuleEditModal.razor
+++ b/src/FrontEASE.Client/Pages/Management/Tabs/Core/Modules/Edit/ModuleEditModal.razor
@@ -1,0 +1,155 @@
+@inject ICoreApiService coreApiService
+@inject IUIService uiService
+@inject IResourceHandler resourceHandler
+@inject Blazored.Toast.Services.IToastService toastService
+
+<Modal @ref="@EditModal" Class="modal-dialog-wide" Border="Border.Rounded" @onkeydown="@(async (e) => await HandleKeyDown(e))" Centered>
+    @if (isModalVisible)
+    {
+        <ModalContent Shadow="Shadow.Small" Class="bg-custom-primary">
+
+            <GenericModalHeader DisplayText="@($"{resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Update}")} - {(!string.IsNullOrWhiteSpace(Module.LongName) ? Module.LongName : (Module.ShortName ?? resourceHandler.GetResource($"{UIConstants.Data}.{UIConstants.Generic}.{UIValueConstants.NotAvailable}")))}")" />
+
+            <ModalBody Margin="Margin.Is3.FromTop">
+
+                @if (isLoading)
+                {
+                    <ContentLoadSpinner />
+                }
+                else
+                {
+                    <Validations @ref="Validations" Mode="ValidationMode.Manual" ValidateOnLoad="false">
+
+                        <Row>
+                            <Column ColumnSize="ColumnSize.IsFull">
+                                <PythonCodeEditor @bind-Value="moduleContent" Height="520px" />
+                            </Column>
+                        </Row>
+
+                        <Validation Validator="@ValidateModuleContent">
+                            <Field ColumnSize="ColumnSize.IsFull" Class="input-validation-only">
+                                <MemoInput ReadOnly="true"
+                                           Placeholder=""
+                                           @bind-Value="@moduleContent">
+                                    <Feedback>
+                                        <ValidationError Multiline="true" />
+                                    </Feedback>
+                                </MemoInput>
+                            </Field>
+                        </Validation>
+
+                        <Row Margin="Margin.Is4.FromTop">
+                            <Column ColumnSize="ColumnSize.Is4.OnWidescreen.Is5.OnMobile">
+                                <Button Clicked="@SaveModule" Class="btn btn-sized button full-width bg-custom-info text-custom-info" Disabled="@updateInProgress" TextWeight="TextWeight.Bold">
+                                    @if (updateInProgress)
+                                    {
+                                        <SpinnerButton SmallControlSpinner="true" DisplayText="@(resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Save}"))" TextSize="TextSize.Medium" />
+                                    }
+                                    else
+                                    {
+                                        @resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Save}")
+                                    }
+                                </Button>
+                            </Column>
+                            <Column ColumnSize="ColumnSize.Is4.OnWidescreen.Is4.WithOffset.OnWidescreen.Is5.OnMobile.Is2.WithOffset.OnMobile">
+                                <Button Clicked="@HideModal" Class="btn btn-sized button full-width text-custom-primary" TextWeight="TextWeight.Bold" Border="Border.Is1.Rounded">
+                                    @resourceHandler.GetResource($"{UIConstants.Data}.{UIConstants.Generic}.{UIValueConstants.No}")
+                                </Button>
+                            </Column>
+                        </Row>
+
+                    </Validations>
+                }
+            </ModalBody>
+
+        </ModalContent>
+    }
+</Modal>
+
+@code {
+    [Parameter]
+    public TaskModuleNoValidationDto Module { get; set; } = new();
+
+    private Modal EditModal = new();
+    private Validations Validations = new();
+
+    private string moduleContent = string.Empty;
+    private bool isModalVisible = false;
+    private bool isLoading = false;
+    private bool updateInProgress = false;
+
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        switch (ShortcutKeyDictionary.GetEnumForm(e.Key))
+        {
+            case ShortcutKeys.ESCAPE:
+                await HideModal();
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void ValidateModuleContent(ValidatorEventArgs args)
+    {
+        var content = Convert.ToString(args.Value) ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(content))
+        {
+            args.Status = ValidationStatus.Error;
+            args.ErrorText = resourceHandler.GetResource($"{UIConstants.Data}.{UIConstants.Specific}.{UIStateConstants.Validation}.{UIValidationConstants.ModuleContentNotEmpty}");
+            return;
+        }
+
+        if (!content.Contains("class ") && !content.Contains("def "))
+        {
+            args.Status = ValidationStatus.Error;
+            args.ErrorText = resourceHandler.GetResource($"{UIConstants.Data}.{UIConstants.Specific}.{UIStateConstants.Validation}.{UIValidationConstants.ModuleContentPythonSyntax}");
+            return;
+        }
+
+        args.Status = ValidationStatus.Success;
+    }
+
+    public async Task SaveModule()
+    {
+        updateInProgress = true;
+
+        if (await Validations.ValidateAll())
+        {
+            var updated = await coreApiService.UpdateTaskCoreModule(Module.ShortName, moduleContent);
+            if (updated)
+            {
+                var message = $"{resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Result}.{UIStateConstants.ActionSuccess}")} - {resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Update}")}: {(!string.IsNullOrWhiteSpace(Module.LongName) ? Module.LongName : Module.ShortName)}";
+                toastService.ShowSuccess(message);
+                await uiService.CallRequestRefreshAsync();
+                await HideModal();
+            }
+        }
+
+        updateInProgress = false;
+    }
+
+    private Task HideModal()
+    {
+        isModalVisible = false;
+        return EditModal.Hide();
+    }
+
+    public async Task ShowModal()
+    {
+        isModalVisible = true;
+        isLoading = true;
+        moduleContent = string.Empty;
+        await EditModal.Show();
+
+        var content = await coreApiService.GetTaskCoreModuleContent(Module.ShortName);
+        if (content is not null)
+        {
+            moduleContent = content;
+        }
+
+        isLoading = false;
+        StateHasChanged();
+    }
+}

--- a/src/FrontEASE.Client/Pages/Management/Tabs/Core/Modules/List/Items/Components/CoreModuleListItemHeader.razor
+++ b/src/FrontEASE.Client/Pages/Management/Tabs/Core/Modules/List/Items/Components/CoreModuleListItemHeader.razor
@@ -3,6 +3,9 @@
 <Row Class="gx-0 margin-background-offset-top-1">
     <CardHeader Display="Display.Flex" Border="Border.RoundedZero" Class="text-custom-primary bg-custom-secondary" Padding="Padding.Is2.FromEnd.Is2.FromStart">
         <Column ColumnSize="ColumnSize.Is12" TextAlignment="TextAlignment.End" Class="align-self-center">
+            <Tooltip Multiline="true" Text="@(resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Update}"))" Display="Display.InlineBlock" Padding="Padding.Is1.FromEnd" Placement="TooltipPlacement.Top">
+                <Icon Class="action-icon action-icon-info" Name="IconName.Pen" IconSize="IconSize.Large" IconStyle="IconStyle.Solid" Clicked="@(async () => await ShowEditModal())" />
+            </Tooltip>
             <Tooltip Multiline="true" Text="@(resourceHandler.GetResource($"{UIConstants.Base}.{UIConstants.Generic}.{UIActionConstants.Delete}"))" Display="Display.InlineBlock" Padding="Padding.Is1.FromEnd" Placement="TooltipPlacement.Top">
                 <Icon Class="action-icon action-icon-danger" Name="IconName.Delete" IconSize="IconSize.Large" IconStyle="IconStyle.Solid" Clicked="@(async () => await ShowDeleteModal())" />
             </Tooltip>
@@ -10,13 +13,16 @@
     </CardHeader>
 </Row>
 
+<ModuleEditModal @ref="@editModal" Module="Module"></ModuleEditModal>
 <ModuleDeleteModal @ref="@deleteModal" Module="Module"></ModuleDeleteModal>
 
 @code {
     [Parameter]
     public TaskModuleNoValidationDto Module { get; set; } = new();
 
+    private ModuleEditModal editModal { get; set; } = new();
     private ModuleDeleteModal deleteModal { get; set; } = new();
 
+    private Task ShowEditModal() => editModal.ShowModal();
     private Task ShowDeleteModal() => deleteModal.ShowModal();
 }

--- a/src/FrontEASE.Client/Services/ApiServices/Shared/Core/CoreApiService.cs
+++ b/src/FrontEASE.Client/Services/ApiServices/Shared/Core/CoreApiService.cs
@@ -38,6 +38,32 @@ namespace FrontEASE.Client.Services.ApiServices.Shared.Core
             return true;
         }
 
+        public async Task<string?> GetTaskCoreModuleContent(string moduleName)
+        {
+            var url = $"{CoreControllerConstants.BaseUrl}/{CoreControllerConstants.Module}/{moduleName}";
+            var response = await _client.GetAsync(url);
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                await _errorHandlingService.HandleErrorResponse(response);
+                return null;
+            }
+            var result = await response.Content.ReadFromJsonAsync<CoreModuleContentDto>();
+            return result?.Content;
+        }
+
+        public async Task<bool> UpdateTaskCoreModule(string moduleName, string content)
+        {
+            var url = $"{CoreControllerConstants.BaseUrl}/{CoreControllerConstants.Module}/{moduleName}";
+            var payload = new CoreModuleContentDto { Content = content };
+            var response = await _client.PutAsJsonAsync(url, payload);
+            if (response.StatusCode != HttpStatusCode.NoContent)
+            {
+                await _errorHandlingService.HandleErrorResponse(response);
+                return false;
+            }
+            return true;
+        }
+
         public async Task<bool> UpdateCoreModels()
         {
             var url = $"{CoreControllerConstants.BaseUrl}/{CoreControllerConstants.Models}";

--- a/src/FrontEASE.Client/Services/ApiServices/Shared/Core/ICoreApiService.cs
+++ b/src/FrontEASE.Client/Services/ApiServices/Shared/Core/ICoreApiService.cs
@@ -7,6 +7,8 @@ namespace FrontEASE.Client.Services.ApiServices.Shared.Core
     {
         Task<IList<ModuleImportBulkActionResultDto>> ImportTaskCoreModules(GlobalPreferenceCoreModuleDto modules);
         Task<bool> DeleteTaskCoreModule(string moduleName);
+        Task<string?> GetTaskCoreModuleContent(string moduleName);
+        Task<bool> UpdateTaskCoreModule(string moduleName, string content);
         Task<bool> UpdateCoreModels();
         Task<string?> GetAvailableModels();
         Task<bool> SaveAvailableModels(string modelsJson);

--- a/src/FrontEASE.Client/Shared/Components/Forms/PythonCodeEditor.razor
+++ b/src/FrontEASE.Client/Shared/Components/Forms/PythonCodeEditor.razor
@@ -1,0 +1,55 @@
+@inject IJSRuntime JSRuntime
+@implements IAsyncDisposable
+
+<div id="@EditorId" style="height: @Height; border: 1px solid #333; border-radius: 4px;"></div>
+
+@code {
+    [Parameter]
+    public string Value { get; set; } = string.Empty;
+
+    [Parameter]
+    public EventCallback<string> ValueChanged { get; set; }
+
+    [Parameter]
+    public string Height { get; set; } = "460px";
+
+    private string EditorId { get; set; } = $"monaco-python-{Guid.NewGuid():N}";
+    private DotNetObjectReference<PythonCodeEditor>? dotNetRef;
+    private bool isInitialized = false;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            dotNetRef = DotNetObjectReference.Create(this);
+            await JSRuntime.InvokeVoidAsync("monacoCreate", EditorId, Value, dotNetRef);
+            isInitialized = true;
+        }
+    }
+
+    [JSInvokable]
+    public async Task OnContentChanged(string newValue)
+    {
+        Value = newValue;
+        await ValueChanged.InvokeAsync(newValue);
+    }
+
+    public async Task SetValue(string value)
+    {
+        Value = value;
+        if (isInitialized)
+        {
+            await JSRuntime.InvokeVoidAsync("monacoSetValue", EditorId, value);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (isInitialized)
+        {
+            try { await JSRuntime.InvokeVoidAsync("monacoDispose", EditorId); }
+            catch { }
+        }
+        dotNetRef?.Dispose();
+    }
+}

--- a/src/FrontEASE.Client/_Imports.razor
+++ b/src/FrontEASE.Client/_Imports.razor
@@ -214,6 +214,7 @@
 @using FrontEASE.Client.Pages.Management.Tabs.Core.Modules
 @using FrontEASE.Client.Pages.Management.Tabs.Core.Modules.Add
 @using FrontEASE.Client.Pages.Management.Tabs.Core.Modules.Delete
+@using FrontEASE.Client.Pages.Management.Tabs.Core.Modules.Edit
 @using FrontEASE.Client.Pages.Management.Tabs.Core.Modules.List
 @using FrontEASE.Client.Pages.Management.Tabs.Core.Modules.List.Items
 @using FrontEASE.Client.Pages.Management.Tabs.Core.Modules.List.Items.Components

--- a/src/FrontEASE.Client/wwwroot/index.html
+++ b/src/FrontEASE.Client/wwwroot/index.html
@@ -17,6 +17,8 @@
     <link rel="stylesheet" href="styles/toast.css" />
 
     <link rel="icon" type="image/png" href="favicon.ico" />
+
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/min/vs/editor/editor.main.css" />
 </head>
 
 <body>
@@ -29,6 +31,10 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/ace-builds@1.36.5/src-min-noconflict/ace.js" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/min/vs/loader.js"></script>
+    <script>
+        require.config({ paths: { 'vs': 'https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/min/vs' } });
+    </script>
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="scripts/code-editor.js"></script>
     <script src="scripts/app.js"></script>

--- a/src/FrontEASE.Client/wwwroot/scripts/app.js
+++ b/src/FrontEASE.Client/wwwroot/scripts/app.js
@@ -8,3 +8,58 @@
     anchor.click();
     URL.revokeObjectURL(url);
 };
+
+window.monacoEditors = {};
+
+window.monacoCreate = function (elementId, value, dotNetRef) {
+    require(['vs/editor/editor.main'], function () {
+        const container = document.getElementById(elementId);
+        if (!container) return;
+
+        const isDark = document.documentElement.getAttribute('data-bs-theme') === 'dark'
+            || document.body.classList.contains('dark')
+            || window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+        const editor = monaco.editor.create(container, {
+            value: value || '',
+            language: 'python',
+            theme: 'vs-dark',
+            minimap: { enabled: false },
+            automaticLayout: true,
+            fontSize: 13,
+            lineNumbers: 'on',
+            scrollBeyondLastLine: false,
+            wordWrap: 'off',
+            tabSize: 4,
+            insertSpaces: true,
+            renderLineHighlight: 'line',
+            scrollbar: { verticalScrollbarSize: 8, horizontalScrollbarSize: 8 }
+        });
+
+        editor.onDidChangeModelContent(function () {
+            dotNetRef.invokeMethodAsync('OnContentChanged', editor.getValue());
+        });
+
+        window.monacoEditors[elementId] = editor;
+    });
+};
+
+window.monacoSetValue = function (elementId, value) {
+    const editor = window.monacoEditors[elementId];
+    if (editor) {
+        editor.setValue(value || '');
+    }
+};
+
+window.monacoGetValue = function (elementId) {
+    const editor = window.monacoEditors[elementId];
+    return editor ? editor.getValue() : '';
+};
+
+window.monacoDispose = function (elementId) {
+    const editor = window.monacoEditors[elementId];
+    if (editor) {
+        editor.dispose();
+        delete window.monacoEditors[elementId];
+    }
+};

--- a/src/FrontEASE.Domain/Services/Core/Connector/CoreConnector.cs
+++ b/src/FrontEASE.Domain/Services/Core/Connector/CoreConnector.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using FrontEASE.DataContracts.Converters.Tasks.Parameters;
 using FrontEASE.DataContracts.Models.Core.Errors;
+using FrontEASE.Shared.Data.DTOs.Management.Core.Modules;
 using FrontEASE.DataContracts.Models.Core.Packages;
 using FrontEASE.DataContracts.Models.Core.Tasks.Data.Configs;
 using FrontEASE.DataContracts.Models.Core.Tasks.Data.Configs.Modules;
@@ -110,6 +111,34 @@ namespace FrontEASE.Domain.Services.Core.Connector
             {
                 var failResult = await response.Content.ReadAsStringAsync(cancellationToken);
                 throw new ApplicationException($"{nameof(DeleteModule)} - Call FAILED - Exception: {failResult}");
+            }
+        }
+
+        public async Task<string> ReadModule(string shortName, CancellationToken cancellationToken)
+        {
+            var url = new Uri($"{_appSettings.IntegrationSettings!.PythonCore!.Server!.BaseUrl}/system/read/{shortName}");
+            var response = await _httpClient.GetAsync(url, cancellationToken);
+            if (response.IsSuccessStatusCode)
+            {
+                var result = await response.Content.ReadFromJsonAsync<CoreModuleContentDto>(_serializerOptions, cancellationToken);
+                return result?.Content ?? string.Empty;
+            }
+            else
+            {
+                var failResult = await response.Content.ReadAsStringAsync(cancellationToken);
+                throw new ApplicationException($"{nameof(ReadModule)} - Call FAILED - Exception: {failResult}");
+            }
+        }
+
+        public async Task UpdateModule(string shortName, string content, CancellationToken cancellationToken)
+        {
+            var url = new Uri($"{_appSettings.IntegrationSettings!.PythonCore!.Server!.BaseUrl}/system/update/{shortName}");
+            var payload = new { content };
+            var response = await _httpClient.PutAsJsonAsync(url, payload, cancellationToken);
+            if (!response.IsSuccessStatusCode)
+            {
+                var failResult = await response.Content.ReadAsStringAsync(cancellationToken);
+                throw new ApplicationException($"{nameof(UpdateModule)} - Call FAILED - Exception: {failResult}");
             }
         }
 

--- a/src/FrontEASE.Domain/Services/Core/Connector/ICoreConnector.cs
+++ b/src/FrontEASE.Domain/Services/Core/Connector/ICoreConnector.cs
@@ -20,6 +20,8 @@ namespace FrontEASE.Domain.Services.Core.Connector
         Task<FileStreamResult> DownloadTaskSolution(Guid taskID, Guid messageID, CancellationToken cancellationToken);
         Task ImportModule(Entities.Shared.Files.File moduleFile, CancellationToken cancellationToken);
         Task<bool> DeleteModule(string shortName, CancellationToken cancellationToken);
+        Task<string> ReadModule(string shortName, CancellationToken cancellationToken);
+        Task UpdateModule(string shortName, string content, CancellationToken cancellationToken);
         Task<bool> UpdateModels(CancellationToken cancellationToken);
         Task<string> GetAvailableModels(CancellationToken cancellationToken);
         Task<bool> SaveAvailableModels(string modelsJson, CancellationToken cancellationToken);

--- a/src/FrontEASE.Domain/Services/Core/CoreService.cs
+++ b/src/FrontEASE.Domain/Services/Core/CoreService.cs
@@ -6,6 +6,8 @@ namespace FrontEASE.Domain.Services.Core
     {
         public async Task ImportCoreModule(Entities.Shared.Files.File fileModule, CancellationToken cancellationToken) => await coreConnector.ImportModule(fileModule, cancellationToken);
         public async Task DeleteCoreModule(string name, CancellationToken cancellationToken) => await coreConnector.DeleteModule(name, cancellationToken);
+        public async Task<string> ReadCoreModule(string name, CancellationToken cancellationToken) => await coreConnector.ReadModule(name, cancellationToken);
+        public async Task UpdateCoreModule(string name, string content, CancellationToken cancellationToken) => await coreConnector.UpdateModule(name, content, cancellationToken);
         public async Task UpdateCoreModels(CancellationToken cancellationToken) => await coreConnector.UpdateModels(cancellationToken);
         public async Task<string> GetAvailableModels(CancellationToken cancellationToken) => await coreConnector.GetAvailableModels(cancellationToken);
         public async Task SaveAvailableModels(string modelsJson, CancellationToken cancellationToken) => await coreConnector.SaveAvailableModels(modelsJson, cancellationToken);

--- a/src/FrontEASE.Domain/Services/Core/ICoreService.cs
+++ b/src/FrontEASE.Domain/Services/Core/ICoreService.cs
@@ -4,6 +4,8 @@
     {
         Task ImportCoreModule(Entities.Shared.Files.File fileModule, CancellationToken cancellationToken);
         Task DeleteCoreModule(string name, CancellationToken cancellationToken);
+        Task<string> ReadCoreModule(string name, CancellationToken cancellationToken);
+        Task UpdateCoreModule(string name, string content, CancellationToken cancellationToken);
         Task UpdateCoreModels(CancellationToken cancellationToken);
         Task<string> GetAvailableModels(CancellationToken cancellationToken);
         Task SaveAvailableModels(string modelsJson, CancellationToken cancellationToken);

--- a/src/FrontEASE.Infrastructure/Data/Configuration/Shared/Resources/Defaults/DefaultResourcesConfiguration.cs
+++ b/src/FrontEASE.Infrastructure/Data/Configuration/Shared/Resources/Defaults/DefaultResourcesConfiguration.cs
@@ -147,6 +147,9 @@ namespace FrontEASE.Infrastructure.Data.Configuration.Shared.Resources.Defaults
 
                 new Resource(){ CountryCodeID = LanguageCode.EN, ResourceCode = $"{UIConstants.Data}.{UIConstants.Specific}.{UIStateConstants.Validation}.{UIValidationConstants.JsonEmpty}", Value="JSON content cannot be empty."},
                 new Resource(){ CountryCodeID = LanguageCode.EN, ResourceCode = $"{UIConstants.Data}.{UIConstants.Specific}.{UIStateConstants.Validation}.{UIValidationConstants.JsonInvalid}", Value="Invalid JSON format"},
+
+                new Resource(){ CountryCodeID = LanguageCode.EN, ResourceCode = $"{UIConstants.Data}.{UIConstants.Specific}.{UIStateConstants.Validation}.{UIValidationConstants.ModuleContentNotEmpty}", Value="Module content cannot be empty." },
+                new Resource(){ CountryCodeID = LanguageCode.EN, ResourceCode = $"{UIConstants.Data}.{UIConstants.Specific}.{UIStateConstants.Validation}.{UIValidationConstants.ModuleContentPythonSyntax}", Value="Module content must contain at least one class or function definition." },
             ];
         }
 

--- a/src/FrontEASE.Server/Controllers/Admin/CoreController.cs
+++ b/src/FrontEASE.Server/Controllers/Admin/CoreController.cs
@@ -51,6 +51,56 @@ namespace FrontEASE.Server.Controllers.Admin
         }
 
         /// <summary>
+        /// Gets the source code content of a core module
+        /// </summary>
+        /// <param name="name">Short name of the module.</param>
+        /// <returns>Module source code content.</returns>
+        [HttpGet($"{CoreControllerConstants.BaseUrl}/{CoreControllerConstants.Module}/{CoreControllerConstants.NameParam}")]
+        [ProducesResponseType(typeof(CoreModuleContentDto), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(UnauthorizedResultDto), (int)HttpStatusCode.Unauthorized)]
+        public async Task<IActionResult> GetCoreModuleContent([FromRoute, Required] string name)
+        {
+            IActionResult result;
+            try
+            {
+                var content = await coreAppService.ReadModule(name, CancellationToken.None);
+                result = GetHttpResult(HttpStatusCode.OK, new CoreModuleContentDto { Content = content });
+            }
+            catch (Exception ex)
+            {
+                var response = ProcessApiException(ex);
+                result = GetHttpResult(response!.StatusCode, response);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Updates the source code content of a core module
+        /// </summary>
+        /// <param name="name">Short name of the module.</param>
+        /// <param name="moduleContent">New module source code content.</param>
+        /// <returns>No content.</returns>
+        [HttpPut($"{CoreControllerConstants.BaseUrl}/{CoreControllerConstants.Module}/{CoreControllerConstants.NameParam}")]
+        [ProducesResponseType((int)HttpStatusCode.NoContent)]
+        [ProducesResponseType(typeof(UnauthorizedResultDto), (int)HttpStatusCode.Unauthorized)]
+        public async Task<IActionResult> UpdateCoreModule([FromRoute, Required] string name, [FromBody, Required] CoreModuleContentDto moduleContent)
+        {
+            IActionResult result;
+            try
+            {
+                ValidateModel();
+                await coreAppService.UpdateModule(name, moduleContent.Content, CancellationToken.None);
+                result = GetHttpResult(HttpStatusCode.NoContent);
+            }
+            catch (Exception ex)
+            {
+                var response = ProcessApiException(ex);
+                result = GetHttpResult(response!.StatusCode, response);
+            }
+            return result;
+        }
+
+        /// <summary>
         /// Deletes the core module
         /// </summary>
         /// <param name="name">Short name of the deleted module.</param>

--- a/src/FrontEASE.Shared/Data/DTOs/Management/Core/Modules/CoreModuleContentDto.cs
+++ b/src/FrontEASE.Shared/Data/DTOs/Management/Core/Modules/CoreModuleContentDto.cs
@@ -1,0 +1,7 @@
+namespace FrontEASE.Shared.Data.DTOs.Management.Core.Modules
+{
+    public class CoreModuleContentDto
+    {
+        public string Content { get; set; } = string.Empty;
+    }
+}

--- a/src/FrontEASE.Shared/Infrastructure/Constants/UI/Generic/UIValidationConstants.cs
+++ b/src/FrontEASE.Shared/Infrastructure/Constants/UI/Generic/UIValidationConstants.cs
@@ -27,5 +27,8 @@
 
         public const string JsonEmpty = "JsonEmpty";
         public const string JsonInvalid = "JsonInvalid";
+
+        public const string ModuleContentNotEmpty = "ModuleContentNotEmpty";
+        public const string ModuleContentPythonSyntax = "ModuleContentPythonSyntax";
     }
 }


### PR DESCRIPTION
## Summary
Full-stack feature for reading and editing imported Python module source code through the management UI. Includes a reusable Monaco Editor component for Python with syntax highlighting, hot-reload support, and client-side basic validation.

## New Reusable Component
**`PythonCodeEditor.razor`** (`Shared/Components/Forms/`) — wraps Monaco Editor with Blazor JS interop. Parameters: `Value`, `ValueChanged`, `Height`. Usable anywhere via `<PythonCodeEditor @bind-Value="@code" Height="460px" />`.

## Architecture (full stack)
```
Python Core (GET/PUT /system/read|update/{short_name})
  |
CoreConnector -> CoreService -> CoreAppService -> CoreController
  |                                                    |
ICoreConnector  ICoreService  ICoreAppService   GET/PUT /api/core/module/{name}
                                                        |
                                            CoreApiService (client HTTP)
                                                        |
                                        ModuleEditModal.razor
                                            (Monaco Editor UI)
```

## Changed Files

### New files (3)
- `Shared/Components/Forms/PythonCodeEditor.razor` — reusable Monaco Editor component
- `Pages/.../Core/Modules/Edit/ModuleEditModal.razor` — edit modal with Monaco editor
- `Shared/Data/DTOs/Management/Core/Modules/CoreModuleContentDto.cs` — shared DTO

### Modified files (15)
| Layer | File | Change |
|-------|------|--------|
| **Client** | `index.html` | Monaco Editor CDN (loader.js + require.config) |
| **Client** | `app.js` | `monacoCreate/getValue/setValue/dispose` JS functions |
| **Client** | `_Imports.razor` | Added `@using` for new Edit namespace |
| **Client** | `CoreModuleListItemHeader.razor` | Added Edit (pen icon) button |
| **Client** | `CoreApiService.cs` / `ICoreApiService.cs` | `GetTaskCoreModuleContent` / `UpdateTaskCoreModule` HTTP methods |
| **Server** | `CoreController.cs` | `GET/PUT /api/core/module/{name}` endpoints (Admin-only) |
| **Application** | `CoreAppService.cs` / `ICoreAppService.cs` | `ReadModule`, `UpdateModule` pass-throughs |
| **Domain** | `CoreService.cs` / `ICoreService.cs` | Pass-through methods |
| **Domain** | `CoreConnector.cs` / `ICoreConnector.cs` | HTTP calls to Python Core |
| **Infrastructure** | `DefaultResourcesConfiguration.cs` | 2 new EN validation resources |
| **Shared** | `UIValidationConstants.cs` | `ModuleContentNotEmpty`, `ModuleContentPythonSyntax` |

## Features
- Python syntax highlighting via Monaco Editor (`vs-dark` theme)
- Edit modal opens from module list item header (pen icon)
- Loads module source code on modal open
- Save with client-side validation (non-empty, contains `class`/`def`)
- Module hot-reloads in Core after save (no restart needed)

## Dependencies
- [Monaco Editor v0.52.0](https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/) (CDN, MIT license)
- Requires corresponding EASE Core PR for the Python read/update endpoints